### PR TITLE
Change finally to then after cli v3 switch

### DIFF
--- a/src/views/Acc.vue
+++ b/src/views/Acc.vue
@@ -96,10 +96,11 @@ export default {
           }
           this.showError()
         })
-        .finally(() => {
+        .then(() => {
           this.account = ''
           this.requestPending = false
           loading.dismiss()
+          return
         })
     },
     showError() {

--- a/src/views/Pwd.vue
+++ b/src/views/Pwd.vue
@@ -118,11 +118,12 @@ export default {
           return false
         })
         .catch(err => console.error(err))
-        .finally(() => {
+        .then(() => {
           // Reset and unblock subsequent requests
           this.pwd = ''
           this.requestPending = false
           loading.dismiss()
+          return
         })
     },
     search(hash, text) {


### PR DESCRIPTION
After the switch to vue cli v3 the webpack config had also changed and the support for non-official stuff was dropped, such as `.finally()`