### PR TITLE
Add default back route, remove unneeded event triggers

### DIFF
--- a/src/views/Acc.vue
+++ b/src/views/Acc.vue
@@ -2,8 +2,8 @@
   <ion-page class="ion-page">
     <ion-header>
       <ion-toolbar>
-        <ion-buttons slot="start" @click="goHome">
-          <ion-back-button/>
+        <ion-buttons slot="start">
+          <ion-back-button default-href="/" />
         </ion-buttons>
         <ion-title>Check Account</ion-title>
         <ion-buttons slot="end">
@@ -111,12 +111,6 @@ export default {
         })
         .then(e => e.present())
         .catch(err => console.error(err))
-    },
-    goHome(event) {
-      if (event) {
-        event.preventDefault()
-      }
-      this.$router.push('/')
     },
   },
 }

--- a/src/views/Breaches.vue
+++ b/src/views/Breaches.vue
@@ -3,7 +3,7 @@
     <ion-header>
       <ion-toolbar>
         <ion-buttons slot="start">
-          <ion-back-button/>
+          <ion-back-button default-href="/acc" />
         </ion-buttons>
         <ion-title v-html="account"/>
       </ion-toolbar>

--- a/src/views/Pwd.vue
+++ b/src/views/Pwd.vue
@@ -2,8 +2,8 @@
   <ion-page class="ion-page">
     <ion-header>
       <ion-toolbar>
-        <ion-buttons slot="start" @click="goHome">
-          <ion-back-button />
+        <ion-buttons slot="start">
+          <ion-back-button default-href="/" />
         </ion-buttons>
         <ion-title>Check Password</ion-title>
         <ion-buttons slot="end">
@@ -142,12 +142,6 @@ export default {
       }
 
       return breachData[1]
-    },
-    goHome(event) {
-      if (event) {
-        event.preventDefault()
-      }
-      this.$router.push('/')
     },
   },
 }

--- a/src/views/Safe.vue
+++ b/src/views/Safe.vue
@@ -3,7 +3,7 @@
     <ion-header>
       <ion-toolbar>
         <ion-buttons slot="start">
-          <ion-back-button/>
+          <ion-back-button default-href="/pwd" />
         </ion-buttons>
       </ion-toolbar>
     </ion-header>

--- a/src/views/Unsafe.vue
+++ b/src/views/Unsafe.vue
@@ -3,7 +3,7 @@
     <ion-header>
       <ion-toolbar>
         <ion-buttons slot="start">
-          <ion-back-button/>
+          <ion-back-button default-href="/pwd" />
         </ion-buttons>
       </ion-toolbar>
     </ion-header>


### PR DESCRIPTION
`default-href` adds a fallback route to go to on hard page reloads, not necessarily needed for a mobile app, but at the very least useful for devs.
Removed extra click triggers