### PR TITLE
Don't delete the dist dir on prod builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "build": "vue-cli-service build --no-clean",
     "lint": "vue-cli-service lint",
     "test:unit": "vue-cli-service test:unit"
   },


### PR DESCRIPTION
`npm run build` by default deletes the `dist/` dir thus removing the `.git` file and making our github pages worktree unusable 