### PR TITLE
Remove input:invalid styling

### DIFF
--- a/src/theme/common.css
+++ b/src/theme/common.css
@@ -63,6 +63,10 @@ ion-title {
   transform: translateY(-50%);
 }
 
+input:invalid {
+  box-shadow: none;
+}
+
 #lottie {
   position:relative;
   width: 100%;


### PR DESCRIPTION
Firefox by default adds a red outline around invalid elements, in our case we use an input type email to enable a specific keyboard layout but also support non email strings, this fixes the inappropriate styling.