### PR TITLE
Fix type-o causing white icons on a white statusbar in iOS

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -26,7 +26,7 @@ new Vue({
   router,
   mounted() {
     SplashScreen.hide()
-    StatusBar.setStyle({ style: this.isIOS ? StatusBarStyle.Light : StatusBarStyle.Dark })
+    StatusBar.setStyle({ style: this.$isIOS ? StatusBarStyle.Light : StatusBarStyle.Dark })
     StatusBar.setBackgroundColor({ color: helpers.env('INITIAL_STATUSBAR_COLOR') })
   },
 }).$mount('#app')


### PR DESCRIPTION
Fix type-o causing white icons on a white statusbar in iOS