### PR TITLE
HockeyApp Android deployment via Fastlane

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -10,7 +10,7 @@ android {
         applicationId "app.modus.beep"
         minSdkVersion 21
         targetSdkVersion 27
-        versionCode 3
+        versionCode 4
         versionName "1.0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -49,4 +49,12 @@ platform :android do
     increment_version_code gradle_build: 'app/build.gradle'
     gradle(task: "clean assembleRelease")
   end
+
+  lane :hockeybeta do
+    increment_version_code gradle_build: 'app/build.gradle'
+    gradle(task: "clean assembleRelease")
+    hockey(
+      api_token: ENV["HOCKEY_API_TOKEN"]
+    )
+  end
 end


### PR DESCRIPTION
Requires HOCKEY_API_TOKEN

Command: `fastlane hockeybeta`