### PR TITLE
GI#71: Fixing style for How it works element

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -160,6 +160,7 @@ h2 {
   font-size: 18px;
   font-weight: 300;
   letter-spacing: -0.48px;
+  display: inline-block;
 }
 
 h2 span {


### PR DESCRIPTION
Changing display style from `inherit` to `inline-block` on the `How it works` h2 element into the `Home` view in order to keep it centered below the buttons section no matter the size of the screen. 