### PR TITLE
Add example keystore file, update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ fastlane/test_output
 /android/app/release
 android/signing/*
 !android/signing/.gitkeep
+!android/signing/keystore.properties.example

--- a/README.md
+++ b/README.md
@@ -106,6 +106,21 @@ After the SDK is setup you can create an Android-specific build by executing:
 npm run build-android
 ```
 
+To create a production or debug APK you will need to [sign your app](https://developer.android.com/studio/publish/app-signing).
+For a local debug build we have provided an example file
+
+```sh
+mv android/signing/keystore.properties.example android/signing/keystore.properties
+```
+
+This will rename the example file and allow you to proceed with the build process.
+
+You may need to adjust the value of `storeFile` according to your platform
+
+```sh
+storeFile=~/.android/debug.keystore
+```
+
 ## Deploying
 
 To prepare your assets for a production deployment execute:

--- a/android/signing/keystore.properties.example
+++ b/android/signing/keystore.properties.example
@@ -1,0 +1,4 @@
+storePassword=myStorePassword
+keyPassword=mykeyPassword
+keyAlias=myKeyAlias
+storeFile=~/.android/debug.keystore


### PR DESCRIPTION
The latest changes require developers to have a `keystore.properties` file, which for obvious reasons is not shipped. I am proposing to include an example file which can be used for local and debug builds.