### PR TITLE
Close app on hardware back button press

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -41,10 +41,17 @@
 
 <script>
 import hasModal from '@/mixins/hasModal'
+import { Plugins } from '@capacitor/core'
+const { App } = Plugins
 
 export default {
   name: 'Home',
   mixins: [hasModal],
+  data() {
+    return {
+      backEvent: null,
+    }
+  },
   methods: {
     goToAcc() {
       this.$router.push('/acc')
@@ -52,9 +59,22 @@ export default {
     goToPwd() {
       this.$router.push('/pwd')
     },
+    handleHardwareBackButton() {
+      if (this.isModalOpen) {
+        return this.$ionic.modalController.dismiss()
+      }
+
+      navigator.app.exitApp()
+    },
   },
   mounted() {
     this.modal = () => import('@/components/HowDoesItWorkModal.vue')
+  },
+  created() {
+    this.backEvent = App.addListener('backButton', this.handleHardwareBackButton)
+  },
+  destroyed() {
+    this.backEvent.remove()
   },
 }
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -74,7 +74,9 @@ export default {
     this.backEvent = App.addListener('backButton', this.handleHardwareBackButton)
   },
   destroyed() {
-    this.backEvent.remove()
+    if (this.backEvent && this.backEvent.remove) {
+      this.backEvent.remove()
+    }
   },
 }
 </script>


### PR DESCRIPTION
Fixes #83 Add support for Android's native behaviour - when there's no history to go back to, close the app.
In order to function properly this will require an upstream update: https://github.com/ionic-team/capacitor/pull/803

I suggest we merge this and wait for the above to be released, in fact we depend on this PR as well:
https://github.com/ionic-team/capacitor/pull/801
When above is done, we release a new version.