### PR TITLE
Improve usage of Capacitor's App API

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -64,14 +64,16 @@ export default {
         return this.$ionic.modalController.dismiss()
       }
 
-      navigator.app.exitApp()
+      App.exitApp()
     },
   },
   mounted() {
     this.modal = () => import('@/components/HowDoesItWorkModal.vue')
   },
   created() {
-    this.backEvent = App.addListener('backButton', this.handleHardwareBackButton)
+    this.backEvent = App.addListener('backButton', this.handleHardwareBackButton).catch(
+      this.$helpers.err
+    )
   },
   destroyed() {
     if (this.backEvent && this.backEvent.remove) {


### PR DESCRIPTION
Supress production error for PWA/web version, switch to using Capacitor's `exitApp` method