### PR TITLE
RFC: Full screen modals refactor

### DIFF
--- a/src/mixins/hasModal.js
+++ b/src/mixins/hasModal.js
@@ -12,14 +12,16 @@ export default {
     next(!this.isModalOpen)
   },
   methods: {
-    toggleModal() {
+    toggleModal(modalComponent = null) {
       if (!this.isModalOpen) {
-        this.openModal()
+        this.openModal(modalComponent)
       }
       this.isModalOpen = !this.isModalOpen
     },
-    async openModal() {
-      const modal = await this.$ionic.modalController.create({ component: this.modal })
+    async openModal(modalComponent = null) {
+      const modal = await this.$ionic.modalController.create({
+        component: modalComponent || this.modal,
+      })
       modal.present()
       return modal.onDidDismiss().then(this.toggleModal)
     },

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -34,7 +34,7 @@
           </div>
         </div>
       </div>
-      <h2 @click="toggleModal"><span>How does it work?</span></h2>
+      <h2 @click="goToHelp"><span>How does it work?</span></h2>
     </ion-content>
   </ion-page>
 </template>
@@ -65,6 +65,9 @@ export default {
       }
 
       App.exitApp()
+    },
+    goToHelp() {
+      this.toggleModal()
     },
   },
   mounted() {

--- a/src/views/Pwd.vue
+++ b/src/views/Pwd.vue
@@ -46,7 +46,7 @@
           <input type="submit" class="form-submit-button"/>
         </form>
       </div>
-      <div class="hash-protected-holder" @click="toggleModal">
+      <div class="hash-protected-holder" @click="goToHelp">
         <div class="hash-protected-inner">
           <img class="hash-protected-img" src="../images/Icon-Hash-Protected.svg" alt="Hash protected"/>
           <span>Hash protected</span>
@@ -153,6 +153,9 @@ export default {
       }
 
       return breachData[1]
+    },
+    goToHelp() {
+      this.toggleModal()
     },
   },
 }

--- a/src/views/Unsafe.vue
+++ b/src/views/Unsafe.vue
@@ -17,7 +17,7 @@
         v-html="count"/>
       <h2 class="count-text">websites</h2>
       <div id="lottie"></div>
-      <h3 @click="toggleModal">
+      <h3 @click="goToHelp">
         <span>What should you do?</span>
       </h3>
       <h3 @click="goToAcc">
@@ -73,6 +73,9 @@ export default {
         autoplay: true,
         name: 'unsafe',
       })
+    },
+    goToHelp() {
+      this.toggleModal()
     },
   },
 }


### PR DESCRIPTION
The current code base assumes every view can trigger one and only one _full screen modal components_

This PR refactors a little but the `hasModal` mixin in order to let it functionality to receive eventual modals as parameters, but it still relies on the default implementation in case there are still views that will be triggering only one full screen modal.

This refactor will make it easier to implemente requested changes on https://github.com/ModusCreateOrg/beep/pull/103

### Steps to test:
1. On Home view, click on `How does it work?` link. Help modal should display normally.
1. On Password view, click on `Hash protected` link. Help modal should display normally.
1. Go to password view, check password `123`. You should be redirected to the Unsafe view. Once you are there, click on `What should you do?` link. Help modal should display normally.