### PR TITLE
use LogoPath from haveibeenpwned API

### DIFF
--- a/src/breachesService.js
+++ b/src/breachesService.js
@@ -2,15 +2,11 @@ export default {
   breaches: [],
   filter: '',
   account: '',
-  baseImageURL: 'https://haveibeenpwned.com/Content/Images/PwnedLogos/',
   baseApiURL: 'https://haveibeenpwned.com/api/v2/breachedaccount/',
   clear() {
     this.breaches = []
     this.filter = ''
     this.account = ''
-  },
-  getImageURL(breach) {
-    return this.baseImageURL + breach.Name + '.' + breach.LogoType
   },
   formatDomain(domain) {
     return domain.startsWith('www') ? domain : `www.${domain}`

--- a/src/components/BreachItem.vue
+++ b/src/components/BreachItem.vue
@@ -2,7 +2,7 @@
   <ion-item @click="viewBreach">
     <ion-avatar slot="start">
       <div class="img-holder">
-        <img :src="this.$breachesService.getImageURL(breach)" :alt="breach.Title"/>
+        <img :src="breach.LogoPath" :alt="breach.Title"/>
       </div>
       <div class="avatar-shadow"/>
     </ion-avatar>

--- a/src/views/Breach.vue
+++ b/src/views/Breach.vue
@@ -12,7 +12,7 @@
         <ion-item>
           <ion-avatar slot="start">
             <div class="img-holder">
-              <img :src="this.$breachesService.getImageURL(breach)" :alt="breach.Title"/>
+              <img :src="breach.LogoPath" :alt="breach.Title"/>
             </div>
             <div class="avatar-shadow"/>
           </ion-avatar>


### PR DESCRIPTION
I noticed the API response is different from what is written in the code which was causing all the breach images to not load. I updated the components to use the new property `LogoPath` instead of building the url using the `breachesService.getImageUrl` method.