### PR TITLE
Update build-android and build-ios scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "lint": "vue-cli-service lint",
     "test:unit": "vue-cli-service test:unit",
     "test:ui": "cd tests_root/wdio && npm run test:local:chrome",
-    "build-android": "npm run build && npx cap sync android && npx cap copy android",
-    "build-ios": "npm run build && npx cap sync && npx cap copy ios",
+    "build-android": "npm run build && npx cap sync android",
+    "build-ios": "npm run build && npx cap sync ios",
     "build-native": "npm run build-android && npm run build-ios"
   },
   "dependencies": {


### PR DESCRIPTION
`npx cap sync` does `npx cap update` + `npx cap copy`, so you don't need an extra copy
Also iOS sync was missing ios