### PR TITLE
#138 Android: the Compromised Password screen shoudn't scroll vertically

### DIFF
--- a/src/theme/common.css
+++ b/src/theme/common.css
@@ -60,7 +60,7 @@ input:invalid {
 #lottie {
   position: relative;
   width: 100%;
-  height: 300px;
+  height: 40vh;
 }
 
 div[style].cloned-input {


### PR DESCRIPTION
Adjusted the compromised password screen image height to be responsive using viewport.

Fixes #138